### PR TITLE
[rend2] Fix gore buffer incorrectly using `glBufferSubData` when immutable

### DIFF
--- a/code/rd-rend2/tr_init.cpp
+++ b/code/rd-rend2/tr_init.cpp
@@ -2051,6 +2051,11 @@ static void R_ShutdownBackEndFrameData()
 			R_BindIBO(frame->dynamicIbo);
 			qglUnmapBuffer(GL_ARRAY_BUFFER);
 			qglUnmapBuffer(GL_ELEMENT_ARRAY_BUFFER);
+
+			R_BindVBO(frame->goreVBO);
+			R_BindIBO(frame->goreIBO);
+			qglUnmapBuffer(GL_ARRAY_BUFFER);
+			qglUnmapBuffer(GL_ELEMENT_ARRAY_BUFFER);
 		}
 
 		for ( int j = 0; j < MAX_GPU_TIMERS; j++ )

--- a/code/rd-rend2/tr_init.cpp
+++ b/code/rd-rend2/tr_init.cpp
@@ -1789,6 +1789,25 @@ static void R_InitGoreVertexData(gpuFrame_t *currentFrame)
 		sizeof(glIndex_t) * (MAX_GORE_RECORDS + 1) * MAX_GORE_INDECIES,
 		VBO_USAGE_DYNAMIC, va("Gore_%i", numGoreArrays));
 
+	if ( glRefConfig.immutableBuffers )
+	{
+		const GLbitfield mapFlags = GL_MAP_WRITE_BIT | GL_MAP_PERSISTENT_BIT | GL_MAP_COHERENT_BIT;
+
+		R_BindVBO(currentFrame->goreVBO);
+		currentFrame->goreVBOMemory = qglMapBufferRange(GL_ARRAY_BUFFER, 0,
+			currentFrame->goreVBO->vertexesSize, mapFlags);
+
+		R_BindIBO(currentFrame->goreIBO);
+		currentFrame->goreIBOMemory = qglMapBufferRange(GL_ELEMENT_ARRAY_BUFFER, 0,
+			currentFrame->goreIBO->indexesSize, mapFlags);
+	}
+	else
+	{
+		currentFrame->goreVBOMemory = nullptr;
+		currentFrame->goreIBOMemory = nullptr;
+	}
+
+	numGoreArrays++;
 	GL_CheckErrors();
 }
 #endif

--- a/code/rd-rend2/tr_init.cpp
+++ b/code/rd-rend2/tr_init.cpp
@@ -2052,10 +2052,12 @@ static void R_ShutdownBackEndFrameData()
 			qglUnmapBuffer(GL_ARRAY_BUFFER);
 			qglUnmapBuffer(GL_ELEMENT_ARRAY_BUFFER);
 
+#ifdef _G2_GORE
 			R_BindVBO(frame->goreVBO);
 			R_BindIBO(frame->goreIBO);
 			qglUnmapBuffer(GL_ARRAY_BUFFER);
 			qglUnmapBuffer(GL_ELEMENT_ARRAY_BUFFER);
+#endif
 		}
 
 		for ( int j = 0; j < MAX_GPU_TIMERS; j++ )

--- a/codemp/rd-rend2/tr_init.cpp
+++ b/codemp/rd-rend2/tr_init.cpp
@@ -1738,6 +1738,24 @@ static void R_InitGoreVertexData(gpuFrame_t* currentFrame)
 		sizeof(glIndex_t) * (MAX_GORE_RECORDS + 1) * MAX_GORE_INDECIES,
 		VBO_USAGE_DYNAMIC, va("Gore_%i", numGoreArrays));
 
+	if ( glRefConfig.immutableBuffers )
+	{
+		const GLbitfield mapFlags = GL_MAP_WRITE_BIT | GL_MAP_PERSISTENT_BIT | GL_MAP_COHERENT_BIT;
+
+		R_BindVBO(currentFrame->goreVBO);
+		currentFrame->goreVBOMemory = qglMapBufferRange(GL_ARRAY_BUFFER, 0,
+			currentFrame->goreVBO->vertexesSize, mapFlags);
+
+		R_BindIBO(currentFrame->goreIBO);
+		currentFrame->goreIBOMemory = qglMapBufferRange(GL_ELEMENT_ARRAY_BUFFER, 0,
+			currentFrame->goreIBO->indexesSize, mapFlags);
+	}
+	else
+	{
+		currentFrame->goreVBOMemory = nullptr;
+		currentFrame->goreIBOMemory = nullptr;
+	}
+
 	numGoreArrays++;
 	GL_CheckErrors();
 }

--- a/codemp/rd-rend2/tr_init.cpp
+++ b/codemp/rd-rend2/tr_init.cpp
@@ -1995,6 +1995,11 @@ static void R_ShutdownBackEndFrameData()
 			R_BindIBO(frame->dynamicIbo);
 			qglUnmapBuffer(GL_ARRAY_BUFFER);
 			qglUnmapBuffer(GL_ELEMENT_ARRAY_BUFFER);
+
+			R_BindVBO(frame->goreVBO);
+			R_BindIBO(frame->goreIBO);
+			qglUnmapBuffer(GL_ARRAY_BUFFER);
+			qglUnmapBuffer(GL_ELEMENT_ARRAY_BUFFER);
 		}
 
 		for ( int j = 0; j < MAX_GPU_TIMERS; j++ )

--- a/codemp/rd-rend2/tr_init.cpp
+++ b/codemp/rd-rend2/tr_init.cpp
@@ -1996,10 +1996,12 @@ static void R_ShutdownBackEndFrameData()
 			qglUnmapBuffer(GL_ARRAY_BUFFER);
 			qglUnmapBuffer(GL_ELEMENT_ARRAY_BUFFER);
 
+#ifdef _G2_GORE
 			R_BindVBO(frame->goreVBO);
 			R_BindIBO(frame->goreIBO);
 			qglUnmapBuffer(GL_ARRAY_BUFFER);
 			qglUnmapBuffer(GL_ELEMENT_ARRAY_BUFFER);
+#endif
 		}
 
 		for ( int j = 0; j < MAX_GPU_TIMERS; j++ )

--- a/shared/rd-rend2/tr_local.h
+++ b/shared/rd-rend2/tr_local.h
@@ -3840,8 +3840,10 @@ struct gpuFrame_t
 
 #ifdef _G2_GORE
 	VBO_t					*goreVBO;
+	void					*goreVBOMemory;
 	int						goreVBOCurrentIndex;
 	IBO_t					*goreIBO;
+	void					*goreIBOMemory;
 	int						goreIBOCurrentIndex;
 #endif
 

--- a/shared/rd-rend2/tr_vbo.cpp
+++ b/shared/rd-rend2/tr_vbo.cpp
@@ -707,12 +707,21 @@ void RB_UpdateGoreVertexData(gpuFrame_t *currentFrame, srfG2GoreSurface_t *goreS
 	}
 
 	R_BindVBO(currentFrame->goreVBO);
-	qglBufferSubData(
-		GL_ARRAY_BUFFER,
-		sizeof(g2GoreVert_t) * goreSurface->firstVert,
-		sizeof(g2GoreVert_t) * goreSurface->numVerts,
-		goreSurface->verts
-	);
+
+	if ( glRefConfig.immutableBuffers )
+	{
+		void *writePtr = (byte *)currentFrame->goreVBOMemory + sizeof(g2GoreVert_t) * goreSurface->firstVert;
+		memcpy(writePtr, (byte *)goreSurface->verts, sizeof(g2GoreVert_t) * goreSurface->numVerts);
+	}
+	else
+	{
+		qglBufferSubData(
+			GL_ARRAY_BUFFER,
+			sizeof(g2GoreVert_t) * goreSurface->firstVert,
+			sizeof(g2GoreVert_t) * goreSurface->numVerts,
+			goreSurface->verts
+		);
+	}
 
 	if (updateFirstVertAndIndex)
 	{
@@ -723,12 +732,21 @@ void RB_UpdateGoreVertexData(gpuFrame_t *currentFrame, srfG2GoreSurface_t *goreS
 	}
 
 	R_BindIBO(currentFrame->goreIBO);
-	qglBufferSubData(
-		GL_ELEMENT_ARRAY_BUFFER,
-		sizeof(glIndex_t) * goreSurface->firstIndex,
-		sizeof(glIndex_t) * goreSurface->numIndexes,
-		goreSurface->indexes
-	);
+
+	if ( glRefConfig.immutableBuffers )
+	{
+		void *writePtr = (byte *)currentFrame->goreIBOMemory + sizeof(glIndex_t) * goreSurface->firstIndex;
+		memcpy(writePtr, goreSurface->indexes, sizeof(glIndex_t) * goreSurface->numIndexes);
+	}
+	else
+	{
+		qglBufferSubData(
+			GL_ELEMENT_ARRAY_BUFFER,
+			sizeof(glIndex_t) * goreSurface->firstIndex,
+			sizeof(glIndex_t) * goreSurface->numIndexes,
+			goreSurface->indexes
+		);
+	}
 
 	if (updateFirstVertAndIndex)
 	{


### PR DESCRIPTION
Immutable buffers cannot be updated with `glBufferSubData` after creation if they do not have `GL_DYNAMIC_STORAGE_BIT` set. This fixes ghoul2 gore marks not working in SP rend2 (MP rend2 doesn't use immutable buffers? or the code paths differ in some other way? IDK).